### PR TITLE
Removed home from navbar Because it violated DRY principle

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,9 +24,6 @@
       <a href="#" class="nav-logo">WebDev</a>
       <ul class="nav-menu">
         <li class="nav-item">
-          <a href="#" class="nav-link">Home</a>
-        </li>
-        <li class="nav-item">
           <a href="#skillsID" class="nav-link">Skills</a>
         </li>
         <li class="nav-item">


### PR DESCRIPTION
Don't Repeat Yourself was violated in the navbar as most users will go to home page by clicking on the logo so the home on navbar is redundant , it gives the website a more minimalistic look