### PR TITLE
added underline hover effect on icons

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -362,4 +362,36 @@ body .cursor .cursor__ball circle {
   z-index: 99;
 }
 
+footer a
+{
+ 
+  display: inline-block;
+  position: relative;
+  color: #0087ca;
+}
+
+
+
+
+footer a:after
+{
+  content: '';
+  position: absolute;
+  width: 100%;
+  transform: scaleX(0);
+  height: 2px;
+  bottom: 0;
+  left: 0;
+  background-color: wheat;
+  transform-origin: bottom right;
+  transition: transform 0.25s ease-out;
+
+}
+
+footer a:hover:after
+{
+  transform: scaleX(1);
+  transform-origin: bottom left;
+}
+
 


### PR DESCRIPTION
Added the underline hover effects over the social media icons in the footer section.

![image](https://user-images.githubusercontent.com/78411069/195558406-d4a171b2-4d00-43b6-9742-5e9b9bc4f6a7.png)
